### PR TITLE
Browser detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*/__pycache__
 /.DS_Store
 /Webdrivers/*
+.secrets

--- a/Regression/accordion_carousel.py
+++ b/Regression/accordion_carousel.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
-    
+def runTest(baseUrl, driver, browser):
+
+    print(' - Testing on {}'.format(browser))    
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     accordion_carousel_page = "{}/en/money-troubles/way-forward/job-loss".format(baseUrl)

--- a/Regression/article_template.py
+++ b/Regression/article_template.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
     articlelist = SourceFileLoader('getarticlelist', '../Lib/article_list.py').load_module()
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()

--- a/Regression/blog_post.py
+++ b/Regression/blog_post.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import requests
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
     blogpostlist = SourceFileLoader('getblogpostlist', '../Lib/blog_post_list.py').load_module()
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()

--- a/Regression/breadcrumbs.py
+++ b/Regression/breadcrumbs.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
     articlelist = SourceFileLoader('getarticlelist', '../Lib/article_list.py').load_module()
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()

--- a/Regression/callouts.py
+++ b/Regression/callouts.py
@@ -2,8 +2,9 @@ from xml import dom
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
     
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     urls = [

--- a/Regression/chat.py
+++ b/Regression/chat.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 

--- a/Regression/cookies.py
+++ b/Regression/cookies.py
@@ -57,8 +57,9 @@ def confirm_marketing_only(driver):
     assert marketing_only_passed
     print('- Correct cookies set for marketing only option')
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     driver.get(baseUrl)

--- a/Regression/emergency_banner.py
+++ b/Regression/emergency_banner.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     articlelist = SourceFileLoader('getarticlelist', '../Lib/article_list.py').load_module()
 

--- a/Regression/footer_follow.py
+++ b/Regression/footer_follow.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     # Maximise window

--- a/Regression/global_card.py
+++ b/Regression/global_card.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     global_card_page = "{}/en/money-troubles/way-forward".format(baseUrl)

--- a/Regression/header.py
+++ b/Regression/header.py
@@ -3,8 +3,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     localeUrls = {

--- a/Regression/home_hero.py
+++ b/Regression/home_hero.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     locale = {

--- a/Regression/icon_anchor.py
+++ b/Regression/icon_anchor.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     # ---------- Icon Anchor ---------- #

--- a/Regression/images.py
+++ b/Regression/images.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     urls = [
         "/en",
         "/cy"

--- a/Regression/local_navigation.py
+++ b/Regression/local_navigation.py
@@ -9,8 +9,9 @@ def scrollDown(driver):
     time.sleep(2)
     print("- Scrolling down 50%")
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     articlelist = SourceFileLoader('getarticlelist', '../Lib/article_list.py').load_module()
 

--- a/Regression/misc.py
+++ b/Regression/misc.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     print("\nSTART OF MISC TESTS")
     print("===================")
 

--- a/Regression/navigation.py
+++ b/Regression/navigation.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     locales = [

--- a/Regression/overview_card.py
+++ b/Regression/overview_card.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     overview_card_page = "{}/en/money-troubles/way-forward".format(baseUrl)
 

--- a/Regression/run.py
+++ b/Regression/run.py
@@ -118,7 +118,9 @@ tests = {
     "Text" : text,
 }
 
-test_result = run_tests(tests, browser=caps.get("browser"))
+print(caps.get('browserName'))
+
+test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,
     test_result
@@ -145,7 +147,7 @@ tests = {
     "Tools" : tools
 }
 
-test_result = run_tests(tests, browser=caps.get("browser"))
+test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,
     test_result
@@ -172,7 +174,7 @@ tests = {
     "Search" : search
 }
 
-test_result = run_tests(tests, browser=caps.get("browser"))
+test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,
     test_result
@@ -205,7 +207,7 @@ tests = {
     "Article Template" : article_template,
 }
 
-test_result = run_tests(tests, browser=caps.get("browser"))
+test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,
     test_result
@@ -232,7 +234,7 @@ tests = {
     "SEO" : seo
 }
 
-test_result = run_tests(tests, browser=caps.get("browser"))
+test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,
     test_result
@@ -259,7 +261,7 @@ tests = {
     "MISC" : misc
 }
 
-test_result = run_tests(tests, browser=caps.get("browser"))
+test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,
     test_result

--- a/Regression/run.py
+++ b/Regression/run.py
@@ -118,8 +118,6 @@ tests = {
     "Text" : text,
 }
 
-print(caps.get('browserName'))
-
 test_result = run_tests(tests, browser=caps.get("browserName"))
 clean_up(
     driver,

--- a/Regression/run.py
+++ b/Regression/run.py
@@ -41,11 +41,11 @@ def get_driver():
         desired_capabilities=caps)
     return driver
 
-def run_tests(tests):
+def run_tests(tests, browser):
     try:
         for key, value in tests.items():
             print('Testing {}'.format(key))
-            value.runTest(baseUrl, driver)
+            value.runTest(baseUrl, driver, browser)
             print('End of {} test\n'.format(key))
         test_result = 'pass'
     except AssertionError as e:
@@ -118,7 +118,7 @@ tests = {
     "Text" : text,
 }
 
-test_result = run_tests(tests)
+test_result = run_tests(tests, browser=caps.get("browser"))
 clean_up(
     driver,
     test_result
@@ -145,7 +145,7 @@ tests = {
     "Tools" : tools
 }
 
-test_result = run_tests(tests)
+test_result = run_tests(tests, browser=caps.get("browser"))
 clean_up(
     driver,
     test_result
@@ -172,7 +172,7 @@ tests = {
     "Search" : search
 }
 
-test_result = run_tests(tests)
+test_result = run_tests(tests, browser=caps.get("browser"))
 clean_up(
     driver,
     test_result
@@ -205,7 +205,7 @@ tests = {
     "Article Template" : article_template,
 }
 
-test_result = run_tests(tests)
+test_result = run_tests(tests, browser=caps.get("browser"))
 clean_up(
     driver,
     test_result
@@ -232,7 +232,7 @@ tests = {
     "SEO" : seo
 }
 
-test_result = run_tests(tests)
+test_result = run_tests(tests, browser=caps.get("browser"))
 clean_up(
     driver,
     test_result
@@ -259,7 +259,7 @@ tests = {
     "MISC" : misc
 }
 
-test_result = run_tests(tests)
+test_result = run_tests(tests, browser=caps.get("browser"))
 clean_up(
     driver,
     test_result

--- a/Regression/search.py
+++ b/Regression/search.py
@@ -3,8 +3,9 @@ from selenium.webdriver.common.keys import Keys
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     searchterms = SourceFileLoader('getsearchterms', '../Lib/search_terms.py').load_module()
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()

--- a/Regression/section_hero.py
+++ b/Regression/section_hero.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     # ---------- Section Hero ---------- #

--- a/Regression/seo.py
+++ b/Regression/seo.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
     
+    print(' - Testing on {}'.format(browser))
     eachpagetype = SourceFileLoader('geteachpagetype', '../Lib/each_page_type.py').load_module()
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
 

--- a/Regression/seperator_anchor.py
+++ b/Regression/seperator_anchor.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 

--- a/Regression/social_sharing.py
+++ b/Regression/social_sharing.py
@@ -3,8 +3,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
     
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     articlelist = SourceFileLoader('getarticlelist', '../Lib/article_list.py').load_module()
 

--- a/Regression/subcategory_article_list.py
+++ b/Regression/subcategory_article_list.py
@@ -3,8 +3,9 @@ from selenium.common.exceptions import NoSuchElementException
 from importlib.machinery import SourceFileLoader
 import time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     subcategorypages = SourceFileLoader('getsubcategorypages', '../Lib/subcategory_pages.py').load_module()
 
     urls = subcategorypages.get_subcategory_pages()

--- a/Regression/subcategory_page.py
+++ b/Regression/subcategory_page.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     subcategorypages = SourceFileLoader('getsubcategorypages', '../Lib/subcategory_pages.py').load_module()
     urls = subcategorypages.get_subcategory_pages()
 

--- a/Regression/tag_selector.py
+++ b/Regression/tag_selector.py
@@ -2,8 +2,9 @@ from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 import random, time
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
     
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
 
     tag_selector_page = "{}/en/money-troubles/way-forward/bill-prioritiser".format(baseUrl)

--- a/Regression/teasers.py
+++ b/Regression/teasers.py
@@ -8,8 +8,9 @@ def getImageSize(selector):
     height = image.size["height"]
     return [width, height]
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     teaser_warnings = set()
 

--- a/Regression/text.py
+++ b/Regression/text.py
@@ -1,8 +1,9 @@
 from selenium.webdriver.common.by import By
 from importlib.machinery import SourceFileLoader
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
 
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     articlelist = SourceFileLoader('getarticlelist', '../Lib/article_list.py').load_module()
 

--- a/Regression/tools.py
+++ b/Regression/tools.py
@@ -10,8 +10,9 @@ def verify_status_code(tool_url):
     else:
         raise AssertionError(" - Tool landing page not reachable")
 
-def runTest(baseUrl, driver):
+def runTest(baseUrl, driver, browser):
     
+    print(' - Testing on {}'.format(browser))
     resize = SourceFileLoader('getresize', '../Lib/resize.py').load_module()
     dismisscookie = SourceFileLoader('getcookiefile', '../Lib/dismisscookie.py').load_module()
 


### PR DESCRIPTION
Ive noticed that the width of the containers in safari are narrower on mobile than chrome, to make sure the tests pass everywhere and on every browser this change passes the browser name into each test as a string.

This will allow us to expect different values based on browser, eg:

```
widths = {
  "Safari" : "450px",
  "Chrome" : "500px"
}
for key, value in widths.items():
  if browser == key:
    assert element.get_value_of_css_property('width') == value
```